### PR TITLE
Fix cannot upload model consecutively bug

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -441,7 +441,7 @@ def create_upload_button(label, elem_id, destination_dir, model_tracking_csv="mo
                 for file_hash_str, file_name in modelreader:
                     if hash_str == file_hash_str:
                         return file_name
-        return None
+        return hash_str
 
     def upload_file(file, hash_str):
         file_path = file.name
@@ -531,9 +531,9 @@ def create_upload_button(label, elem_id, destination_dir, model_tracking_csv="mo
     button.click(None, None, None, _js=compute_hash_js)
     hidden_button = gr.Button("Verify hash", elem_id=hidden_button_id, visible=False)
     hidden_button.click(verify_model_existence, hash_str, existing_filepath, api_name="check_hash")
-    existing_filepath.change(None, existing_filepath, None, _js="""
-        (filepath) => {{
-            if (!filepath) {{
+    existing_filepath.change(None, [hash_str, existing_filepath], None, _js="""
+        (hash_str, filepath) => {{
+            if (hash_str == filepath) {{
                 const upload_button = document.querySelector(
                     "body > gradio-app").shadowRoot.querySelector(
                     "#{upload_button_id}");


### PR DESCRIPTION
The current implementation will rely on the return of hash computing backend function to determine whether or not upload the model. IF the hash isn't in the csv file on the disk, that function will always return `None`, which will not trigger the textbox onchange event, which will not run the function that evaluates whether it needs to upload the model or not.