### PR TITLE
Change hash function to chunk by chunk async function

### DIFF
--- a/javascript/hash.js
+++ b/javascript/hash.js
@@ -1,0 +1,96 @@
+var chunkSize = 1024*1024; // bytes
+
+function loading(file, chunkSize, callbackProgress, callbackFinal) {
+    var offset = 0;
+    var partial;
+    var index = 0;
+
+    if(file.size===0){
+        callbackFinal();
+    }
+    var lastOffset = 0;
+    var chunkReorder = 0;
+    var chunkTotal = 0;
+
+    // memory reordering
+    var previous = [];
+    function callbackRead_buffered(reader, file, evt, callbackProgress, callbackFinal){
+        chunkTotal++;
+
+        if(lastOffset !== reader.offset){
+            // out of order
+            previous.push({ offset: reader.offset, size: reader.size, result: reader.result});
+            chunkReorder++;
+            return;
+        }
+
+        function parseResult(offset, size, result) {
+            lastOffset = offset + size;
+            callbackProgress(result);
+            if (offset + size >= file.size) {
+                lastOffset = 0;
+                callbackFinal();
+            }
+        }
+
+        // in order
+        parseResult(reader.offset, reader.size, reader.result);
+
+        // resolve previous buffered
+        var buffered = [{}]
+        while (buffered.length > 0) {
+            buffered = previous.filter(function (item) {
+                return item.offset === lastOffset;
+            });
+            buffered.forEach(function (item) {
+                parseResult(item.offset, item.size, item.result);
+                previous.remove(item);
+            })
+        }
+
+    }
+
+    Array.prototype.remove = Array.prototype.remove || function(val){
+        var i = this.length;
+        while(i--){
+            if (this[i] === val){
+                this.splice(i,1);
+            }
+        }
+    }
+
+    while (offset < file.size) {
+        partial = file.slice(offset, offset+chunkSize);
+        var reader = new FileReader;
+        reader.size = chunkSize;
+        reader.offset = offset;
+        reader.index = index;
+        reader.onload = function(evt) {
+            callbackRead_buffered(this, file, evt, callbackProgress, callbackFinal);
+        };
+        reader.readAsArrayBuffer(partial);
+        offset += chunkSize;
+        index += 1;
+    }
+}
+
+function hashFile(file) {
+    if(file===undefined){
+        return;
+    }
+    var SHA256 = CryptoJS.algo.SHA256.create();
+    var counter = 0;
+
+    var hash_str = new Promise((resolve, reject) => {
+        loading(file, chunkSize,
+            function (data) {
+                var wordBuffer = CryptoJS.lib.WordArray.create(data);
+                SHA256.update(wordBuffer);
+                counter += data.byteLength;
+            }, function (data) {
+                var encrypted = SHA256.finalize().toString();
+                resolve(encrypted);
+            });
+    });
+    return hash_str;
+}

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -468,40 +468,7 @@ def create_upload_button(label, elem_id, destination_dir, model_tracking_csv="mo
             var input_box = upload_button.previousElementSibling;
             var extra_input = input_box.cloneNode();
             extra_input.id = "input-for-hash-{elem_id}";
-            const readbinaryfile = function (file) {{
-                return new Promise((resolve, reject) => {{
-                    var fr = new FileReader();
-                    fr.onload = () => {{
-                        resolve(fr.result)
-                    }};
-                    fr.readAsArrayBuffer(file);
-                }});
-            }}
-            const Uint8ArrayToHexString = function (ui8array) {{
-                var hexstring = '',
-                    h;
-                for (var i = 0; i < ui8array.length; i++) {{
-                    h = ui8array[i].toString(16);
-                    if (h.length == 1) {{
-                        h = '0' + h;
-                    }}
-                    hexstring += h;
-                }}
-                var p = Math.pow(2, Math.ceil(Math.log2(hexstring.length)));
-                hexstring = hexstring.padStart(p, '0');
-                return hexstring;
-            }}
-            const hashfile = function (file) {{
-                return readbinaryfile(file)
-                    .then(function(result) {{
-                        result = new Uint8Array(result);
-                        return window.crypto.subtle.digest('SHA-256', result);
-                    }}).then(function(result) {{
-                        result = new Uint8Array(result);
-                        var resulthex = Uint8ArrayToHexString(result);
-                        return resulthex;
-                    }});
-            }}
+
             extra_input.onchange = async (e) => {{
                 const target = e.target;
                 if (!target.files) return;
@@ -516,7 +483,7 @@ def create_upload_button(label, elem_id, destination_dir, model_tracking_csv="mo
                 }}, 3000);
 
                 input_box.files = target.files;
-                const hash_str = await hashfile(input_box.files[0]);
+                const hash_str = await hashFile(input_box.files[0]);
                 const checkpoint_hash_str = document.querySelector("#{hash_str_id} > label > textarea");
                 checkpoint_hash_str.value = hash_str;
                 const event = new Event("input");
@@ -1959,6 +1926,8 @@ def webpath(fn):
 def javascript_html():
     script_js = os.path.join(script_path, "script.js")
     head = f'<script type="text/javascript" src="{webpath(script_js)}"></script>\n'
+
+    head += '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>\n'
 
     inline = f"{localization.localization_js(shared.opts.localization)};"
     if cmd_opts.theme is not None:


### PR DESCRIPTION
The previous hash function that calculate sha256 will load the entire model into memory on the browser side. However, most of the modern browser only has hundreds MB of memory and we could not compute hash of model which is bigger than 200MB.

Change the hash function to support super big model, since most of the checkpoint will be several GB.