### PR TITLE
Fix the backend setting loading error

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1847,7 +1847,6 @@ def create_ui():
 
     try:
         if os.path.exists(ui_config_file):
-            import json
             with open(ui_config_file, "r", encoding="utf8") as file:
                 import json
                 ui_settings = json.load(file)
@@ -1916,7 +1915,6 @@ def create_ui():
     visit(train_interface, loadsave, "train")
 
     if not error_loading and (not os.path.exists(ui_config_file) or settings_count != len(ui_settings)):
-        import json
         with open(ui_config_file, "w", encoding="utf8") as file:
             json.dump(ui_settings, file, indent=4)
 


### PR DESCRIPTION
The json object has been imported at the top, import in function body will cause the JIT compiler to believe it was used before assignment.