### PR TITLE
Add button to upload model for extra networks

### DIFF
--- a/html/extra-networks-upload-button.html
+++ b/html/extra-networks-upload-button.html
@@ -1,0 +1,5 @@
+<div class='card' style='white-space: nowrap; text-align: center; background-image: none; background-color:rgb(171 176 177 / 40%); {style}' onclick='{card_clicked}'>
+  <span class="helper" style="display: inline-block; height: 100%; vertical-align: middle;"></span>
+  <img id='{plus_sign_elem_id}' style='margin: auto; vertical-align: middle; display:inline-block' src='https://icons.veryicon.com/png/o/miscellaneous/standard-general-linear-icon/plus-60.png'>
+  <img id='{loading_sign_elem_id}' style='margin: auto; vertical-align: middle; display: none' src='https://i.gifer.com/origin/34/34338d26023e5515f6cc8969aa027bca_w200.gif'>
+</div>

--- a/html/footer.html
+++ b/html/footer.html
@@ -17,7 +17,7 @@
 
     <!-- Modal content -->
     <div id="notification-modal-content" class="modal-content">
-        <p style="color: #19974b">Notification.</p>
+        <p style="color: #0fd35d">Notification.</p>
     </div>
 
 </div>
@@ -36,7 +36,7 @@
 
 /* Modal Content */
 #notification-modal-content {{
-    background-color: rgba(68, 222, 148, 0.3);;
+    background-color: rgba(68, 222, 148, 0.5);
     margin: 0px auto;
     padding: 8px;
     text-align: center;


### PR DESCRIPTION
In the extra network section, adding a button for each tab so that user can upload different types of models to different directories.

TODO: The current implementation does not handle the case where there are sub directories within each model folder.