### PR TITLE
Update preview loading mechanism

### DIFF
--- a/modules/paths.py
+++ b/modules/paths.py
@@ -54,11 +54,11 @@ class Paths:
 
         work_dir = base_dir.joinpath('workdir', user.uid)
         if not work_dir.exists():
-            work_dir.mkdir(parents=True)
+            work_dir.mkdir(parents=True, exist_ok=True)
 
         model_dir = base_dir.joinpath('models', user.uid)
         if not model_dir.exists():
-            model_dir.mkdir(parents=True)
+            model_dir.mkdir(parents=True, exist_ok=True)
 
         self._work_dir = work_dir
         self._model_dir = model_dir
@@ -70,7 +70,7 @@ class Paths:
     @staticmethod
     def _check_dir(path):
         if not path.exists():
-            path.mkdir(parents=True)
+            path.mkdir(parents=True, exist_ok=True)
         return path
 
     def outdir(self):
@@ -112,6 +112,10 @@ class Paths:
     # dir to store user models
     def models_dir(self):
         return self._check_dir(self._model_dir)
+
+    # dir to store user model previews
+    def model_previews_dir(self):
+        return self._check_dir(self._work_dir.joinpath("model_previews"))
 
 
 class Prioritize:


### PR DESCRIPTION
We add the following logics in preview:
1. remove absolute path in the frontend
2. add directories of model as the preview search path
3. model preview will be default to previews that reside alongside models
4. each individual can save their own preview, in their own folder
5. If individual preview exists, load individual preview
6. Otherwise, load model default preview
7. If no preview exists, load `no_preview_card.png`