### PR TITLE
Add GPU thread executor pool to execute GPU related tasks

### DIFF
--- a/modules/call_queue.py
+++ b/modules/call_queue.py
@@ -1,25 +1,55 @@
 import html
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
 import traceback
 import time
+import functools
 
 import gradio.routes
 
 import modules.system_monitor
+from modules.system_monitor import MonitorException
 from modules import shared, progress
 
 queue_lock = threading.Lock()
 
+gpu_worker_pool: ThreadPoolExecutor | None = None
 
-def wrap_queued_call(func):
-    def f(*args, **kwargs):
-        with queue_lock:
-            res = func(*args, **kwargs)
 
+def submit_to_gpu_worker(func: callable, timeout: int = 60) -> callable:
+    def call_function_in_gpu_wroker(*args, **kwargs):
+        if gpu_worker_pool is None:
+            raise RuntimeError("GPU worker thread has not been initialized.")
+        future_res = gpu_worker_pool.submit(
+            func, *args, **kwargs)
+        res = future_res.result(timeout=timeout)
         return res
+    return call_function_in_gpu_wroker
 
-    return f
+
+def wrap_gpu_call(request: gradio.routes.Request, func, func_name, id_task, *args, **kwargs):
+    progress.start_task(id_task)
+    shared.state.begin()
+    # log all gpu calls with monitor
+    monitor_log_id = modules.system_monitor.on_task(request, func, *args, **kwargs)
+
+    try:
+        if func_name in ('txt2img', 'img2img'):
+            progress.set_current_task_step('reload_model_weights')
+            _check_sd_model(model_title=args[-1])
+        progress.set_current_task_step('inference')
+        res = func(request, *args, **kwargs)
+        status = 'finished'
+        log_message = 'done'
+    except Exception as e:
+        status = 'failed'
+        log_message = e.__str__()
+        raise e
+    finally:
+        shared.state.end()
+        modules.system_monitor.on_task_finished(request, monitor_log_id, status, log_message)
+    return res
 
 
 def wrap_gradio_gpu_call(func, func_name: str = '', extra_outputs=None, add_monitor_state=False):
@@ -37,43 +67,21 @@ def wrap_gradio_gpu_call(func, func_name: str = '', extra_outputs=None, add_moni
         else:
             id_task = None
 
-        # send gpu call to queue
-        with queue_lock:
-            # log all gpu calls with monitor
-            from modules.system_monitor import MonitorException
-            try:
-                monitor_log_id = modules.system_monitor.on_task(request, func, *args, **kwargs)
-            except MonitorException as e:
-                progress.finish_task(id_task)
-                shared.state.job = ""
-                shared.state.job_count = 0
-                extra_outputs_array = extra_outputs
-                if extra_outputs_array is None:
-                    extra_outputs_array = [None, '', '']
-                if add_monitor_state:
-                    return extra_outputs_array + [str(e)], True
-                return extra_outputs_array + [str(e)]
-
-            shared.state.begin()
-            progress.start_task(id_task)
-
-            try:
-                if func_name in ('txt2img', 'img2img'):
-                    progress.set_current_task_step('reload_model_weights')
-                    _check_sd_model(model_title=args[-1])
-                progress.set_current_task_step('inference')
-                res = func(request, *args, **kwargs)
-                status = 'finished'
-                log_message = 'done'
-            except Exception as e:
-                status = 'failed'
-                log_message = e.__str__()
-                raise e
-            finally:
-                progress.finish_task(id_task)
-                modules.system_monitor.on_task_finished(request, monitor_log_id, status, log_message)
-
+        try:
+            res = submit_to_gpu_worker(
+                functools.partial(wrap_gpu_call, request, func, func_name, id_task), timeout=60 * 10)(*args, **kwargs)
+        except MonitorException as e:
             shared.state.end()
+            extra_outputs_array = extra_outputs
+            if extra_outputs_array is None:
+                extra_outputs_array = [None, '', '']
+            if add_monitor_state:
+                return extra_outputs_array + [str(e)], True
+            return extra_outputs_array + [str(e)]
+        except Exception as e:
+            raise e
+        finally:
+            progress.finish_task(id_task)
 
         if add_monitor_state:
             return res, False

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -16,7 +16,7 @@ import gradio.routes
 import gradio.utils
 import numpy as np
 from PIL import Image, PngImagePlugin
-from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, wrap_gradio_call
+from modules.call_queue import wrap_gradio_gpu_call, submit_to_gpu_worker, wrap_gradio_call
 
 from modules import sd_hijack, sd_models, localization, script_callbacks, ui_extensions, deepbooru, sd_vae, extra_networks, postprocessing, ui_components, ui_common, ui_postprocessing
 from modules.ui_components import FormRow, FormColumn, FormGroup, ToolButton, FormHTML
@@ -669,8 +669,14 @@ def create_ui():
                 height,
             ]
 
-            token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[txt2img_prompt, steps], outputs=[token_counter])
-            negative_token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[txt2img_negative_prompt, steps], outputs=[negative_token_counter])
+            token_button.click(
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                inputs=[txt2img_prompt, steps],
+                outputs=[token_counter])
+            negative_token_button.click(
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                inputs=[txt2img_negative_prompt, steps],
+                outputs=[negative_token_counter])
 
             ui_extra_networks.setup_ui(extra_networks_ui, txt2img_gallery)
 
@@ -967,7 +973,10 @@ def create_ui():
                 )
 
             token_button.click(fn=update_token_counter, inputs=[img2img_prompt, steps], outputs=[token_counter])
-            negative_token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[img2img_negative_prompt, steps], outputs=[negative_token_counter])
+            negative_token_button.click(
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                inputs=[img2img_negative_prompt, steps],
+                outputs=[negative_token_counter])
 
             ui_extra_networks.setup_ui(extra_networks_ui_img2img, img2img_gallery)
 

--- a/webui.py
+++ b/webui.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from packaging import version
+from concurrent.futures import ThreadPoolExecutor
 
 import logging
 
@@ -33,7 +34,8 @@ startup_timer.record("import ldm")
 
 from modules import extra_networks, ui_extra_networks_checkpoints
 from modules import extra_networks_hypernet, ui_extra_networks_hypernets, ui_extra_networks_textual_inversion
-from modules.call_queue import wrap_queued_call, queue_lock, wrap_gradio_gpu_call
+from modules import call_queue
+from modules.call_queue import submit_to_gpu_worker, queue_lock, wrap_gradio_gpu_call
 from modules.ui_common import add_static_filedir_to_demo
 
 # Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
@@ -64,7 +66,7 @@ import modules.hypernetworks.hypernetwork
 
 startup_timer.record("other imports")
 
-MAX_ANYIO_WORKER_THREAD = 5
+MAX_ANYIO_WORKER_THREAD = 64
 
 
 if cmd_opts.server_name:
@@ -105,20 +107,7 @@ Use --skip-version-check commandline argument to disable this check.
 
 
 def initialize():
-    from anyio._backends._asyncio import _default_thread_limiter, CapacityLimiter
-
-    def my_current_default_thread_limiter() -> CapacityLimiter:
-        limiter = CapacityLimiter(int(MAX_ANYIO_WORKER_THREAD))
-        _default_thread_limiter.set(limiter)
-        return limiter
-    import anyio
-    # Set worker idle time to a big number
-    # to avoid the thread being discrad
-    # since we doubt that creating new thread
-    # will cause memory leak, because the older threads
-    # are not gced correctly
-    anyio._backends._asyncio.WorkerThread.MAX_IDLE_TIME = 60 * 60 * 24 * 7
-    anyio._backends._asyncio.current_default_thread_limiter = my_current_default_thread_limiter
+    call_queue.gpu_worker_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu_worker_")
 
     check_versions()
 
@@ -169,9 +158,9 @@ def initialize():
         shared.opts.data["sd_model_checkpoint"] = shared.sd_model.sd_checkpoint_info.title
 
     # do not reload checkpoint after setting updated, but load it before generating images
-    # shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
-    shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
-    shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
+    # shared.opts.onchange("sd_model_checkpoint", submit_to_gpu_worker(lambda: modules.sd_models.reload_model_weights()))
+    shared.opts.onchange("sd_vae", submit_to_gpu_worker(lambda: modules.sd_vae.reload_vae_weights()), call=False)
+    shared.opts.onchange("sd_vae_as_default", submit_to_gpu_worker(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("temp_dir", ui_tempdir.on_tmpdir_changed)
     startup_timer.record("opts onchange")
 


### PR DESCRIPTION
Since we have identify that multiple threads is one reason that causes memory leak. We would like to put all the gpu jobs (or rather pytorch jobs) all in a single thread. We use a thread executor pool to achieve this.
