### PR TITLE
Change the preview loading logic to leverage browser cache

### DIFF
--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -1,10 +1,10 @@
-<div class='card' style={style} onclick={card_clicked}>
+<div class='card' style={style} onclick={card_clicked} filename={filename}>
 	{metadata_button}
 
 	<div class='actions'>
 		<div class='additional'>
 			<ul>
-				<a href="#" title="replace preview image with currently selected in gallery" onclick={save_card_preview}>replace preview</a>
+				<a href="#" title="replace preview image with currently selected in gallery" onclick={save_card_preview}>set private preview</a>
 			</ul>
 			<span style="display:none" class='search_term'>{search_term}</span>
 		</div>

--- a/html/extra-networks-upload-button.html
+++ b/html/extra-networks-upload-button.html
@@ -1,4 +1,4 @@
-<di id='{button_id}' class='card model-upload-button' style='white-space: nowrap; text-align: center; background-image:
+<div id='{button_id}' class='card model-upload-button' style='white-space: nowrap; text-align: center; background-image:
      none; background-color:rgb(171 176 177 / 40%); {style}' onclick='{card_clicked}' model_type='{model_type}'
     uppy_dashboard_title='{dashboard_title}' {model_size}>
   <span class="helper" style="display: inline-block; height: 100%; vertical-align: middle;"></span>


### PR DESCRIPTION
We have changed the preview loading logic to leverage the browser cache. In the previous version, we would like to enable users to save private previews, we add a timmestamp at the end of each image previews. The prpblem is that every time the image url will change when refresh or opened, and cache memachnism is totally ignored.

However, while more and more models are being added, we would like to give this capability back. The users are still be able to add their private model previews, but the ones that does not change will be cached by browser.