### PR TITLE
Updated version of posthog for resovling page freezing issues

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1873,7 +1873,7 @@ def javascript_html():
     head = f'<script type="text/javascript" src="{webpath(script_js)}"></script>\n'
 
     head += '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>\n'
-    head += '<script type="text/javascript" src="/public/js/posthog.js"></script>\n'
+    head += '<script type="text/javascript" src="/public/js/posthog.js?v=0.2"></script>\n'
 
     inline = f"{localization.localization_js(shared.opts.localization)};"
     if cmd_opts.theme is not None:


### PR DESCRIPTION
We saw freezing pages when some extensions enabled, with Posthog enabled. It's fixed by Posthog configuration changes described in the other repo. This change is to update the version of the Javascript file loading and configuring Posthog.