### PR TITLE
Change the gpu call time out to 30 minutes

### DIFF
--- a/modules/call_queue.py
+++ b/modules/call_queue.py
@@ -96,7 +96,7 @@ def wrap_gradio_gpu_call(func, func_name: str = '', extra_outputs=None, add_moni
 
         try:
             res = submit_to_gpu_worker(
-                functools.partial(wrap_gpu_call, request, func, func_name, id_task), timeout=60 * 10)(*args, **kwargs)
+                functools.partial(wrap_gpu_call, request, func, func_name, id_task), timeout=60 * 30)(*args, **kwargs)
         except MonitorException as e:
             extra_outputs_array = extra_outputs
             if extra_outputs_array is None:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -685,11 +685,11 @@ def create_ui():
             ]
 
             token_button.click(
-                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 30),
                 inputs=[txt2img_prompt, steps],
                 outputs=[token_counter])
             negative_token_button.click(
-                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 30),
                 inputs=[txt2img_negative_prompt, steps],
                 outputs=[negative_token_counter])
 
@@ -998,7 +998,7 @@ def create_ui():
 
             token_button.click(fn=update_token_counter, inputs=[img2img_prompt, steps], outputs=[token_counter])
             negative_token_button.click(
-                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 10),
+                fn=submit_to_gpu_worker(update_token_counter, timeout=60 * 30),
                 inputs=[img2img_negative_prompt, steps],
                 outputs=[negative_token_counter])
 


### PR DESCRIPTION
Since some of the jobs will take longer than 10 minutes to run, which was the previously set time out period for GPU jobs. Make it larger by changing from 10 minutes to 20 minutes.