### PR TITLE
Fix the upload button by redirect click to upload button card

### DIFF
--- a/html/extra-networks-upload-button.html
+++ b/html/extra-networks-upload-button.html
@@ -1,5 +1,5 @@
 <div class="card model-upload-button" id='{button_id}' style='display: none; white-space: nowrap; text-align: center; background-image:
-     none; background-color:rgb(171 176 177 / 40%); {style}' onclick='{card_clicked}' model_type='{model_type}'
+     none; background-color:rgb(171 176 177 / 40%); {style}' onclick='{card_clicked}' model_type='{model_type}' tabname='{tabname}'
     uppy_dashboard_title='{dashboard_title}' {model_size}>
   <span class="helper" style="display: inline-block; height: 100%; vertical-align: middle;"></span>
   <img id='{plus_sign_elem_id}' style='margin: auto; vertical-align: middle; display:inline-block' src='/components/icons/plus.png'>

--- a/javascript/upload.mjs
+++ b/javascript/upload.mjs
@@ -5,11 +5,12 @@ if (typeof setup_uppy_for_upload_button != "undefined") {
     const model_verification_endpoint= '/verify-model-existence';
     const uppy_object_map = new Map();
 
-    function refresh_model_list_when_upload_complete(complete_array) {
-        var txt2img_model_refresh_button = gradioApp().querySelector('#txt2img_extra_refresh');
-        var img2img_model_refresh_button = gradioApp().querySelector('#img2img_extra_refresh');
-        txt2img_model_refresh_button.click();
-        img2img_model_refresh_button.click();
+    function refresh_model_list_when_upload_complete_wrapper(tabname) {
+        function refresh_model_list_when_upload_complete(complete_array) {
+            var model_refresh_button = gradioApp().querySelector(`#${tabname}_extra_refresh`);
+            model_refresh_button.click();
+        }
+        return refresh_model_list_when_upload_complete;
     }
 
     function register_button(elem_node){
@@ -21,12 +22,12 @@ if (typeof setup_uppy_for_upload_button != "undefined") {
             uppy_object_map.delete(elem_node.id);
 
             uppy = setup_uppy_for_upload_button(
-                elem_node, tus_endpoint, model_verification_endpoint, refresh_model_list_when_upload_complete);
+                elem_node, tus_endpoint, model_verification_endpoint, refresh_model_list_when_upload_complete_wrapper(elem_node.getAttribute("tabname")));
             uppy_object_map.set(elem_node.id, uppy);
 
         } else {
             const uppy = setup_uppy_for_upload_button(
-                elem_node, tus_endpoint, model_verification_endpoint, refresh_model_list_when_upload_complete);
+                elem_node, tus_endpoint, model_verification_endpoint, refresh_model_list_when_upload_complete_wrapper(elem_node.getAttribute("tabname")));
 
             uppy_object_map.set(elem_node.id, uppy);
         }

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -88,11 +88,11 @@ def get_metadata(page: str = "", item: str = ""):
 
 def get_page_query_model(request: Request, model_type:str, page: int, search_value: str, page_size: int, need_refresh: bool):
     from starlette.responses import JSONResponse
-    
+
     model_list = []
     count = 0
     allow_negative_prompt = False
-    
+
     def item_filter(item: dict) -> bool:
         return search_value in item.get('search_term', '')
 
@@ -105,7 +105,7 @@ def get_page_query_model(request: Request, model_type:str, page: int, search_val
             count = len(items)
             allow_negative_prompt = page_item.allow_negative_prompt
             break
-    
+
     return JSONResponse({
         "page": page,
         "total_count": count,
@@ -248,7 +248,8 @@ class ExtraNetworksPage:
         items_html += shared.html("extra-networks-upload-button.html").format(
             button_id=button_id,
             style=f"{height}{width}",
-            model_type=f'{self_name_id}',
+            model_type=self_name_id,
+            tabname=tabname,
             card_clicked=f'if (typeof register_button == "undefined") {{document.querySelector("#{upload_button_id}").click();}}',
             dashboard_title=f'{self.title} files only.{dashboard_title_hint}',
             model_size=model_size,
@@ -419,10 +420,13 @@ def create_ui(container, button, tabname):
                      with gr.Column(scale=7):
                          gr.Button("hide", visible=False)
                      with gr.Column(elem_id=f"{ui.tabname}_{self_name_id}_upload_btn", elem_classes="pagination_upload_btn", scale=2,  min_width=220):
-                        upload_btn = gr.Button(f"Upload {page.title} Model", elem_classes="model-upload-button", variant="primary")
+                        upload_btn = gr.Button(f"Upload {page.title} Model", variant="primary")
                         upload_btn.click(
                             fn=None,
-                            _js=f'() => {{if (typeof register_button == "undefined") {{document.querySelector("#{upload_button_id}").click();}}}}'
+                            _js=f'''() => {{
+                                if (typeof register_button == "undefined") {{document.querySelector("#{upload_button_id}").click();}}
+                                else {{document.querySelector("#{button_id}").click();}}
+                            }}'''
                         )
                      with gr.Column(elem_id=f"{ui.tabname}_{self_name_id}_pagination_row", elem_classes="pagination_row",  min_width=220):
                         gr.HTML(


### PR DESCRIPTION
We rely on `model_type` attribute to know what type of a model the user is uploading. The gradio button does not ways to set the attribute. Therefore, we redict gradio button click to card button click to give the `registerButton` ability to read `model_type` attribute.