### PR TITLE
Refresh metadata when reading it

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -28,6 +28,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"],
                     metadata["sha256"]])
+                self.metadata[name] = metadata
             yield {
                 "name": name,
                 "filename": path,

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -59,7 +59,10 @@ def fetch_file(request: Request, filename: str = "", model_type: str = ""):
 def get_metadata(page: str = "", item: str = ""):
     from starlette.responses import HTMLResponse
 
-    page = next(iter([x for x in extra_pages if x.name == page]), None)
+    # There are two sources where this api being called
+    # one is construct in python code, which directly users page.name
+    # the other one is in js code which uses model_type
+    page = next(iter([x for x in extra_pages if x.name == page or x.name.lower().replace(" ", "_") == page]), None)
     if page is None:
         return HTMLResponse("<h1>404, could not find page</h1>")
 
@@ -189,8 +192,6 @@ class ExtraNetworksPage:
         view = shared.opts.extra_networks_default_view
         items_html = ''
 
-        self.metadata = {}
-
         subdirs = {}
         for parentdir in [os.path.abspath(x) for x in self.allowed_directories_for_previews()]:
             for x in glob.glob(os.path.join(parentdir, '**/*'), recursive=True):
@@ -215,13 +216,6 @@ class ExtraNetworksPage:
 {html.escape(subdir if subdir!="" else "all")}
 </button>
 """ for subdir in subdirs])
-
-        for item in self.list_items():
-            metadata = item.get("metadata")
-            if metadata:
-                self.metadata[item["name"]] = metadata
-
-            # items_html += self.create_html_for_item(item, tabname)
 
         self_name_id = self.name.replace(" ", "_")
 

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -2,10 +2,9 @@ import html
 import json
 import os
 
-import gradio as gr
-
 from modules import shared, ui_extra_networks, sd_models
 from fastapi import Request
+
 
 class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
     def __init__(self):
@@ -28,6 +27,7 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["tags"]),
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"]])
+                self.metadata[checkpoint.name_for_extra] = metadata
             yield {
                 "name": checkpoint.name_for_extra,
                 "filename": path,

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -27,6 +27,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"],
                     metadata["sha256"]])
+                self.metadata[name] = metadata
 
             yield {
                 "name": name,

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -29,6 +29,7 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"],
                     metadata["sha256"]])
+                self.metadata[embedding.name] = metadata
             yield {
                 "name": embedding.name,
                 "filename": embedding.filename,


### PR DESCRIPTION
Since we no longer use `create_html` function, metadata will never get refreshed. Instead, we push the refresh logic to where we read it, that where it suppose to be anyway.