### PR TITLE
Change lora model lower bound to 5MB

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -9,7 +9,7 @@ from modules import shared, ui_extra_networks
 class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
     def __init__(self):
         super().__init__('Lora')
-        self.min_model_size_mb = 10
+        self.min_model_size_mb = 5
         self.max_model_size_mb = 1e3
 
     def refresh(self, request: gr.Request):


### PR DESCRIPTION
Change lora model lower bound to 5MB, now users should be able to update model as small as 5MB.