### PR TITLE
Move metadata read to extranetwork page refresh

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -12,15 +12,23 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         self.min_model_size_mb = 10
         self.max_model_size_mb = 1e3
 
-    def refresh(self, request: gr.Request):
-        lora.list_available_loras()
-
-    def list_items(self):
+    def refresh_metadata(self):
         for name, lora_on_disk in lora.available_loras.items():
             path, ext = os.path.splitext(lora_on_disk.filename)
             metadata_path = "".join([path, ".meta"])
             metadata = ui_extra_networks.ExtraNetworksPage.read_metadata_from_file(metadata_path)
+            if metadata is not None:
+                self.metadata[name] = metadata
+
+    def refresh(self, request: gr.Request):
+        lora.list_available_loras()
+        self.refresh_metadata()
+
+    def list_items(self):
+        for name, lora_on_disk in lora.available_loras.items():
+            path, ext = os.path.splitext(lora_on_disk.filename)
             search_term = self.search_terms_from_path(lora_on_disk.filename)
+            metadata = self.metadata.get(name, None)
             if metadata is not None:
                 search_term = " ".join([
                     search_term,
@@ -28,7 +36,6 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"],
                     metadata["sha256"]])
-                self.metadata[name] = metadata
             yield {
                 "name": name,
                 "filename": path,

--- a/javascript/notifier.js
+++ b/javascript/notifier.js
@@ -1,6 +1,10 @@
 let notifierGlobalOptions = {
     position: "bottom-right",
     icons: {enabled: false},
+    minDurations: {
+        async: 30,
+        "async-block": 30,
+    },
 };
 
 var notifier = new AWN(notifierGlobalOptions);

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -169,6 +169,9 @@ class ExtraNetworksPage:
     def refresh(self, request: gr.Request):
         pass
 
+    def refresh_metadata(self):
+        pass
+
     def link_preview(self, filename):
         model_type = self.name.replace(" ", "_")
         filename_unix = os.path.abspath(filename.replace('\\', '/'))
@@ -221,6 +224,8 @@ class ExtraNetworksPage:
 """ for subdir in subdirs])
 
         self_name_id = self.name.replace(" ", "_")
+
+        self.refresh_metadata()
 
         # Add a upload model button
         plus_sign_elem_id=f"{tabname}_{self_name_id}-plus-sign"

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -11,15 +11,23 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         self.min_model_size_mb = 10
         self.max_model_size_mb = 1e3
 
-    def refresh(self, request: gr.Request):
-        shared.reload_hypernetworks()
-
-    def list_items(self):
+    def refresh_metadata(self):
         for name, path in shared.hypernetworks.items():
             path, ext = os.path.splitext(path)
             metadata_path = "".join([path, ".meta"])
             metadata = ui_extra_networks.ExtraNetworksPage.read_metadata_from_file(metadata_path)
+            if metadata is not None:
+                self.metadata[name] = metadata
+
+    def refresh(self, request: gr.Request):
+        shared.reload_hypernetworks()
+        self.refresh_metadata()
+
+    def list_items(self):
+        for name, path in shared.hypernetworks.items():
+            path, ext = os.path.splitext(path)
             search_term = self.search_terms_from_path(path)
+            metadata = self.metadata.get(name, None)
             if metadata is not None:
                 search_term = " ".join([
                     search_term,
@@ -27,7 +35,6 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
                     ", ".join(metadata["trigger_word"]),
                     metadata["model_name"],
                     metadata["sha256"]])
-                self.metadata[name] = metadata
 
             yield {
                 "name": name,


### PR DESCRIPTION
Move all the metadata read to page refresh to accelerate the model querying speed.