### PR TITLE
fix: missing plus character of url query

### DIFF
--- a/javascript/autoFillSearchParams.js
+++ b/javascript/autoFillSearchParams.js
@@ -1,5 +1,5 @@
 class AutoFillSearchParams {
-    searchParams = new URLSearchParams(decodeURIComponent(location.search));
+    searchParams = new URLSearchParams(location.search);
     result = '__prompt__ __negative_prompt__';
     paramsKeys = ['prompt', 'negative_prompt', 'width', 'height', 'seed', 'steps', 'sampler', 'cfg', 'clip_skip', 'batch_size', 'ensd']
     defaultWidth = 512;


### PR DESCRIPTION
Dont decoding url param due to missing  plus character of url query