### PR TITLE
do not load sd-models at service startup

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -100,7 +100,7 @@ def setup_model():
     if not os.path.exists(model_path):
         os.makedirs(model_path)
 
-    list_models()
+    # list_models()
     enable_midas_autodownload()
 
 


### PR DESCRIPTION
do not load sd-models at service startup