### PR TITLE
Add a fullback uuid function

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -58,9 +58,18 @@ function setTitle(progress){
     }
 }
 
+function uuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+}
 
 function randomId(){
-    return "task(" + crypto.randomUUID() +")";
+    if (typeof crypto.randomUUID == "function") {
+        return "task(" + crypto.randomUUID() +")";
+    } else {
+        return "task(" + uuidv4() +")";
+    }
 }
 
 // starts sending progress requests to "/internal/progress" uri, creating progressbar above progressbarContainer element and


### PR DESCRIPTION
There could be situation where cryto object is not supported in some browser. We aaded a fallback uuid function to compute uuid when crypto object is missing.