### PR TITLE
Make setting not interactable and could be hide

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -226,6 +226,19 @@ onUiLoaded(function() {
     showRestoreProgressButton('img2img', localStorage.getItem("img2img_task_id"));
 });
 
+onUiLoaded(function() {
+    let gr_tabs = document.querySelector("#tabs");
+    let tab_items = gr_tabs.querySelectorAll(":scope>.tabitem");
+    let tab_buttons = gr_tabs.querySelector(".tab-nav").querySelectorAll(":scope>button");
+    if (tab_items.length === tab_buttons.length) {
+        tab_items.forEach(function(tab_item, index) {
+            if (tab_item.classList.contains("hidden")) {
+                tab_buttons[index].classList.add("hidden");
+            }
+        });
+    }
+});
+
 
 function modelmerger() {
     var id = randomId();

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -118,3 +118,4 @@ parser.add_argument("--logging-level", type=str,  help="logging level, can be on
 parser.add_argument("--model-cache-dir", type=str,  help="User can use a ssd to cache the models to speed up loading speed", default="")
 parser.add_argument("--model-cache-max-size", type=int,  help="The maximum disk space (GB) to use to cache the model. Need to set --model-cache-dir first.", default=0)
 parser.add_argument("--predict-timeout", type=int,  help="Timeout in second of /predict.", default=1800)
+parser.add_argument("--settings-not-interactive", action='store_true', help="Make settings not interactive, but still could be manipulate with program.", default=False)

--- a/modules/timer.py
+++ b/modules/timer.py
@@ -93,7 +93,7 @@ class Timer:
         return {'total': self.total, 'records': self.records}
 
     def reset(self):
-        self.__init__()
+        self.__init__(self._name, *self._args)
 
 
 startup_timer = Timer('main')

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1543,7 +1543,11 @@ def create_ui():
 
     loadsave = ui_loadsave.UiLoadsave(cmd_opts.ui_config_file)
 
-    settings = ui_settings.UiSettings(txt2img_model_title, img2img_model_title, txt2img_vae_title, img2img_vae_title)
+    if any([(tab_name in shared.opts.hidden_tabs) for tab_name in ("Settings", "Setting")]):
+        shared.cmd_opts.settings_not_interactive = True
+    settings = ui_settings.UiSettings(
+        txt2img_model_title, img2img_model_title, txt2img_vae_title, img2img_vae_title,
+        interactive=not shared.cmd_opts.settings_not_interactive)
     settings.create_ui(loadsave, dummy_component)
 
     interfaces = [
@@ -1667,7 +1671,8 @@ def create_ui():
             for interface, label, ifid in sorted_interfaces:
                 if label in shared.opts.hidden_tabs:
                     if label in ('Settings', 'Setting'):
-                        gr.Textbox(elem_id="settings_json", value=lambda: opts.dumpjson(), visible=False)
+                        with gr.TabItem(label, id=ifid, elem_id=f"tab_{ifid}", elem_classes=["hidden"]):
+                            interface.render()
                     continue
                 with gr.TabItem(label, id=ifid, elem_id=f"tab_{ifid}"):
                     interface.render()

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -80,12 +80,14 @@ class UiSettings:
     img2img_model_title = None
     txt2img_vae_title = None
     img2img_vae_title = None
+    interactive = True
 
-    def __init__(self, txt2img_model_title, img2img_model_title, txt2img_vae_title, img2img_vae_title):
+    def __init__(self, txt2img_model_title, img2img_model_title, txt2img_vae_title, img2img_vae_title, interactive=True):
         self.txt2img_model_title = txt2img_model_title
         self.img2img_model_title = img2img_model_title
         self.txt2img_vae_title = txt2img_vae_title
         self.img2img_vae_title = img2img_vae_title
+        self.interactive = interactive
 
     def run_settings(self, request: gr.Request, *args):
         import modules.call_utils
@@ -137,9 +139,17 @@ class UiSettings:
         with gr.Blocks(analytics_enabled=False) as settings_interface:
             with gr.Row():
                 with gr.Column(scale=6):
-                    self.submit = gr.Button(value="Apply settings", variant='primary', elem_id="settings_submit")
+                    self.submit = gr.Button(
+                        value="Apply settings",
+                        variant='primary',
+                        elem_id="settings_submit",
+                        interactive=self.interactive)
                 with gr.Column():
-                    restart_gradio = gr.Button(value='Reload UI', variant='primary', elem_id="settings_restart_gradio")
+                    restart_gradio = gr.Button(
+                        value='Reload UI',
+                        variant='primary',
+                        elem_id="settings_restart_gradio",
+                        interactive=self.interactive)
 
             self.result = gr.HTML(elem_id="settings_result")
 
@@ -176,7 +186,7 @@ class UiSettings:
                     elif section_must_be_skipped:
                         self.components.append(dummy_component)
                     else:
-                        component = create_setting_component(k)
+                        component = create_setting_component(k, interactive=self.interactive)
                         self.component_dict[k] = component
                         self.components.append(component)
 
@@ -192,24 +202,25 @@ class UiSettings:
 
                     with gr.Row():
                         with gr.Column(scale=1):
-                            sysinfo_check_file = gr.File(label="Check system info for validity", type='binary')
+                            sysinfo_check_file = gr.File(
+                                label="Check system info for validity", type='binary', interactive=self.interactive)
                         with gr.Column(scale=1):
                             sysinfo_check_output = gr.HTML("", elem_id="sysinfo_validity")
                         with gr.Column(scale=100):
                             pass
 
                 with gr.TabItem("Actions", id="actions", elem_id="settings_tab_actions"):
-                    request_notifications = gr.Button(value='Request browser notifications', elem_id="request_notifications")
-                    download_localization = gr.Button(value='Download localization template', elem_id="download_localization")
-                    reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies")
+                    request_notifications = gr.Button(value='Request browser notifications', elem_id="request_notifications", interactive=self.interactive)
+                    download_localization = gr.Button(value='Download localization template', elem_id="download_localization", interactive=self.interactive)
+                    reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies", interactive=self.interactive)
                     with gr.Row():
-                        unload_sd_model = gr.Button(value='Unload SD checkpoint to free VRAM', elem_id="sett_unload_sd_model")
-                        reload_sd_model = gr.Button(value='Reload the last SD checkpoint back into VRAM', elem_id="sett_reload_sd_model")
+                        unload_sd_model = gr.Button(value='Unload SD checkpoint to free VRAM', elem_id="sett_unload_sd_model", interactive=self.interactive)
+                        reload_sd_model = gr.Button(value='Reload the last SD checkpoint back into VRAM', elem_id="sett_reload_sd_model", interactive=self.interactive)
 
                 with gr.TabItem("Licenses", id="licenses", elem_id="settings_tab_licenses"):
                     gr.HTML(shared.html("licenses.html"), elem_id="licenses")
 
-                gr.Button(value="Show all pages", elem_id="settings_show_all_pages")
+                gr.Button(value="Show all pages", elem_id="settings_show_all_pages", interactive=self.interactive)
 
                 self.text_settings = gr.Textbox(elem_id="settings_json", value=lambda: opts.dumpjson(), visible=False)
 
@@ -276,7 +287,7 @@ class UiSettings:
     def add_quicksettings(self):
         with gr.Row(elem_id="quicksettings", variant="compact"):
             for _i, k, _item in sorted(self.quicksettings_list, key=lambda x: self.quicksettings_names.get(x[1], x[0])):
-                component = create_setting_component(k, is_quicksettings=True)
+                component = create_setting_component(k, is_quicksettings=True, interactive=self.interactive)
                 self.component_dict[k] = component
 
     def add_functionality(self, demo, sd_model_selection):


### PR DESCRIPTION
Using the original hide tabs configuration will hide the settings and ruin the front js mapping because the html elements are no longer rendered. Add options to still render setting elements on the frontend, but set them to be not interactive and hide the tab from the sight.